### PR TITLE
Don't treat 404s as errors

### DIFF
--- a/pkg/apis/newrelic/v1alpha1/alertchannel_types.go
+++ b/pkg/apis/newrelic/v1alpha1/alertchannel_types.go
@@ -104,6 +104,10 @@ func (s *AlertChannel) Delete(ctx context.Context) error {
 		return fmt.Errorf("alert channel object has not been created %s", s.ObjectMeta.Name)
 	}
 	rsp, err := client.AlertsChannels.DeleteByID(ctx, *id)
+	if rsp.StatusCode == 404 {
+		log.Warn(responseBodyToString(rsp))
+		return nil
+	}
 	err = handleError(rsp, err)
 	if err != nil {
 		return err

--- a/pkg/apis/newrelic/v1alpha1/alertpolicy_types.go
+++ b/pkg/apis/newrelic/v1alpha1/alertpolicy_types.go
@@ -82,6 +82,10 @@ func (s *AlertPolicy) Delete(ctx context.Context) error {
 	}
 
 	rsp, err := client.AlertsPolicies.DeleteByID(ctx, *id)
+	if rsp.StatusCode == 404 {
+		log.Warn(responseBodyToString(rsp))
+		return nil
+	}
 	err = handleError(rsp, err)
 	if err != nil {
 		return err

--- a/pkg/apis/newrelic/v1alpha1/client.go
+++ b/pkg/apis/newrelic/v1alpha1/client.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/IBM/newrelic-cli/newrelic"
 	"github.com/IBM/newrelic-cli/utils"
 )
@@ -57,6 +59,10 @@ func handleError(rsp *newrelic.Response, err error) error {
 	} else if rsp.StatusCode < 200 || rsp.StatusCode >= 300 {
 		buf := new(bytes.Buffer)
 		buf.ReadFrom(rsp.Body)
+		if rsp.StatusCode == 404 {
+			log.Warn(buf.String())
+			return nil // Don't treat 404s as errors
+		}
 		return fmt.Errorf("%s", buf.String())
 	}
 	return nil

--- a/pkg/apis/newrelic/v1alpha1/client.go
+++ b/pkg/apis/newrelic/v1alpha1/client.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/IBM/newrelic-cli/newrelic"
 	"github.com/IBM/newrelic-cli/utils"
 )
@@ -57,13 +55,14 @@ func handleError(rsp *newrelic.Response, err error) error {
 	if err != nil {
 		return fmt.Errorf("newrelic api error %v", err)
 	} else if rsp.StatusCode < 200 || rsp.StatusCode >= 300 {
-		buf := new(bytes.Buffer)
-		buf.ReadFrom(rsp.Body)
-		if rsp.StatusCode == 404 {
-			log.Warn(buf.String())
-			return nil // Don't treat 404s as errors
-		}
-		return fmt.Errorf("%s", buf.String())
+		body := responseBodyToString(rsp)
+		return fmt.Errorf("%s", body)
 	}
 	return nil
+}
+
+func responseBodyToString(rsp *newrelic.Response) string {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(rsp.Body)
+	return buf.String()
 }

--- a/pkg/apis/newrelic/v1alpha1/dashboard_types.go
+++ b/pkg/apis/newrelic/v1alpha1/dashboard_types.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/IBM/newrelic-cli/newrelic"
+	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -66,6 +67,10 @@ func (s *Dashboard) Delete(ctx context.Context) error {
 	}
 
 	rsp, _, err := client.Dashboards.DeleteByID(ctx, *id)
+	if rsp.StatusCode == 404 {
+		log.Warn(responseBodyToString(rsp))
+		return nil
+	}
 	err = handleError(rsp, err)
 	if err != nil {
 		return err

--- a/pkg/apis/newrelic/v1alpha1/monitor_types.go
+++ b/pkg/apis/newrelic/v1alpha1/monitor_types.go
@@ -198,6 +198,10 @@ func (s *Monitor) Delete(ctx context.Context) error {
 	}
 
 	rsp, err := clientSythetics.SyntheticsMonitors.DeleteByID(ctx, id)
+	if rsp.StatusCode == 404 {
+		log.Warn(responseBodyToString(rsp))
+		return nil
+	}
 	err = handleError(rsp, err)
 	if err != nil {
 		return err

--- a/pkg/controller/alertchannel/alertchannel_controller.go
+++ b/pkg/controller/alertchannel/alertchannel_controller.go
@@ -96,8 +96,9 @@ func (r *ReconcileAlertChannel) Reconcile(request reconcile.Request) (reconcile.
 		if err != nil {
 			logger.Error(err)
 			reconcileResult = defaultRequeue
+		} else {
+			instance.SetFinalizers(nil)
 		}
-		instance.SetFinalizers(nil)
 		return reconcile.Result{}, r.client.Update(ctx, instance)
 	} else if instance.IsCreated() {
 		if instance.HasChanged() {


### PR DESCRIPTION
Some resources may not cleanup properly during namespace deletion. This prevents the namespace from being deleted and gets stuck in a terminating state. Manually removing the finalizer from these resources allows the namespace to be cleaned up.