### PR TITLE
Fix CRD spec to allow for floats in `spec.slaThreshold`

### DIFF
--- a/helm/crds/newrelic.shanestarcher.com_monitors_crd.yaml
+++ b/helm/crds/newrelic.shanestarcher.com_monitors_crd.yaml
@@ -67,7 +67,8 @@ spec:
                   type: string
               type: object
             slaThreshold:
-              type: float64
+              type: number
+              format: float
             status:
               type: string
             type:


### PR DESCRIPTION
Guessing this became an issue when we updated the k8s version, not super sure.

Working on:

```
Server Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.8", GitCommit:"ec6eb119b81be488b030e849b9e64fda4caaf33c", GitTreeState:"clean", BuildDate:"2020-03-12T20:52:22Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}
```